### PR TITLE
Update modular_input_base_class.py

### DIFF
--- a/bin/modular_input/modular_input_base_class.py
+++ b/bin/modular_input/modular_input_base_class.py
@@ -697,7 +697,11 @@ class ModularInput(object):
 
             # Throw an exception if the argument could not be found
             else:
-                raise FieldValidationException("The parameter '%s' is not a valid argument" % (name))
+                # raise FieldValidationException("The parameter '%s' is not a valid argument" % (name))
+                # Should following Splunk global spec for inputs.conf.
+                # Usually call Splunk RESTful API to get all supported properties
+                # Just ignore it for this release
+                self.logger.debug("The parameter '{}' is not a valid argument".format(name))
 
         return cleaned_params
 


### PR DESCRIPTION
https://jira.splunk.com/browse/ADDON-26013
Fix the parameter validation to support more Splunk properties in inputs.conf, such as `python.version`